### PR TITLE
Feature/details on processors config

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,12 +279,22 @@ of the column that contains it
 
   *Note:* If you use the schema processor but you don't provide a schema to compare against, the files will be evaluated as having no errors.
 
-  To see how using different processors influence the quality assessment, we set up several versions
+##### Examples:
+  To exemplify how using different processors influences the quality assessment, we set up several versions
   of the same dataset: UK public spend over £25000.
-  
-  This version uses both `structure` and `schema` processors, comparing each file agaist the
-  [spend publishing schema](https://raw.githubusercontent.com/okfn/goodtables/master/examples/hmt/spend-publishing-schema.json).
 
+  [Here](https://uk-25k-structure-only.herokuapp.com/) is a dashboard whose
+  data quality database is assessed only on `structure`. You can find the database and configuration 
+  [in this repository](https://github.com/georgiana-b/data-quality-uk-25k-spend/tree/uk-25k-spend-structure-only).
+
+  [This alternative version](https://uk-25k-given-schema.herokuapp.com/)
+  uses both `structure` and `schema` processors, comparing each file agaist the
+  [spend publishing schema](https://raw.githubusercontent.com/okfn/goodtables/master/examples/hmt/spend-publishing-schema.json).
+  It is the official configuration, with its corresponding repository [here](https://github.com/georgiana-b/data-quality-uk-25k-spend/tree/uk-25k-given-schema).
+
+  Lastly, [here is the less predictible version](https://uk-25k-inferred-schema.herokuapp.com/)
+  that uses both `structure` and `schema`, but it compares files agaist inferred schemas (i.e. using `infer_schema: true`).Corresponding
+  database repostory [here](https://github.com/georgiana-b/data-quality-uk-25k-spend/tree/uk-25k-spend-inferred-schema).
 
 <a name="schema"/>
 ### Schema

--- a/README.md
+++ b/README.md
@@ -4,37 +4,35 @@
 
 # Data Quality CLI
 
-A command line tool that assesses the data quality of a set of data sources (e.g.: CSV files of open data published by a government).
+A command line tool that assesses the quality of a set of data sources (e.g.: CSV files of open data published by a government).
 
 ## What's it about?
 
-The `dq` (alias: `dataquality`) CLI is a batch processor
-
-is for administering data that belongs to a Spend Publishing
-
-Dashboard (dashboard data is in itself a github repository:
-<a href="https://github.com/okfn/spd-data-example">see the example repository here</a>).
+The `dq` (alias: `dataquality`) CLI is a tool to create and manage a [Data Package](http://specs.frictionlessdata.io/data-packages/) 
+from a given source of data that can be used by [Data Quality Dashboard](https://github.com/frictionlessdata/data-quality-dashboard).
+The quality assessment is done using [GoodTables](http://goodtables.readthedocs.io/en/latest/index.html) and [can be configured](#quality-config).
 
 The proposed workflow is this:
 
-* A deployer/administrator runs the validation over a set of data sources at regular intervals
-* The data is managed in a git repository (eg), which the developer has locally
-* The deployer/administrator should have a config file for each Spend Publishing
-Dashboard she is administering
-* The deployer/administrator, or possibly content editor, occasionally updates
-the `sources.csv` file in the data directory with new data sources
-* Periodically (once a month, once a quarter), the deployer/administrator does
+* An administrator creates a folder for a given project which will be equivalent to a data package.
+* The administrator creates a `source_file` and `publisher_file`:
+    * By using the [generate command](#generate).
+    * By using custom scripts ([see this example](https://github.com/okfn/data-quality-uk-25k-spend)).
+    * In any other way that is in sync with the [schema](#schema).
+* The administrator updates the [configuration file](#config) to reflect the structure of the data package 
+and optionally to configure the quality assessment.
+* The administrator [runs the validation](#run) over the set of sources.
+* The data is managed in a git repository (or other version control system), which the administrator has locally
+* The administrator [deploys](#deploy) the data package to a central data repository (ex: GitHub)
+* The administrator [updates the configuration](https://github.com/frictionlessdata/data-quality-dashboard#configure-database)
+of the corresponding Data Quality Dashboard instance
+* The administrator, or possibly content editor, occasionally updates
+the `source_file` file in the data directory with new data
+* Periodically (once a month, once a quarter), the administrator runs
 `dq run /path/to-config.json --deploy`. This builds a new set of results for the data,
-and deploys the updated data back to the central data repository (i.e: GitHub)
-* As the Spend Publishing Dashboard is a pure client-side application, as soon as updated
+and deploys the updated data back to the central data repository
+* Since Data Quality Dashboard is a pure client-side application, as soon as updated
 data is deployed, the app will start working with the updated data.
-
-Note that  deployer/administrator does not need a new `dq` environment per Spend Publishing
-Dashboard that she administers. Rather, there must be a config file per dashboard,
-based on `dq-config.example.json`. For more info about the structure of the config file
-see [this section](###structure-of-jsonconfig).
-
-`dq` currently provides two commands: `run` and `deploy`. Read more about these below.
 
 ## Install
 
@@ -48,7 +46,9 @@ pip install git+https://github.com/okfn/dataquality-cli.git#egg=dataquality
 dq --help
 ```
 
+<a name="run"/>
 ### Run
+</a>
 
 ```
 dq run /path/to/config.json --deploy
@@ -56,11 +56,14 @@ dq run /path/to/config.json --deploy
 
 Runs a *data quality assessment* on all data sources in a data repository.
 
-* Writes aggregated results to the results.csv.
-* Writes run meta data to the run.csv.
+* Writes results for each source to the `result_file`.
+* Writes run meta data to `run_file`.
+* Writes aggregations on results for each publisher in the `performance_file`.
 * If `--deploy` is passed, then also commits, tags and pushes the new changes back to the data repositories central repository.
 
+<a name="run"/>
 ### Deploy
+</a>
 
 ```
 dq deploy /path/to/config.json
@@ -68,7 +71,9 @@ dq deploy /path/to/config.json
 
 Deploys this Data Quality repository to a remote.
 
+<a name="generate"/>
 ### Generate
+</a>
 
 Generic command:
 
@@ -90,24 +95,27 @@ the `--file_type` option. In the example below, we ask for `CSV` and `TXT`:
 dq generate ckan https://data.qld.gov.au/  --file_type csv --file_type txt
 ```
 
-If you want to built a custom Generator, just inherit and overwrite the methods of `data_quality.generators.BaseGenerator` class.
+If you want to built a custom Generator, just inherit and overwrite the methods of [`data_quality.generators.BaseGenerator`](data_quality/generators/base.py) class.
 To load your custom generator class you need to provide the path to it so that it can be imported via
 [importlib.import_module](https://docs.python.org/3/library/importlib.html#importlib.import_module).
 You can either provide it in the config, or by using the `--generator_class_path` option:
 
 ```
 dq generate custom_generator_name endpoint --generator_class_path mymodule.MyGenerator
-
 ```
 
-If no config file is provided, the generator will use the [default configuration](###default-configuration)
+If no config file is provided, the generator will use the [default configuration](#default-config)
 creating the files in the folder where the command is executed. If you want to change that, use the `--config_filepath` option:
 
 ```
 dq generate generator_name endpoint --config_filepath path/to/config
 ```
 
-### Structure of json config
+<a name="config"/>
+### Configuration
+</a>
+
+#### Structure of json config
 
 ```json
 {
@@ -156,7 +164,7 @@ dq generate generator_name endpoint --config_filepath path/to/config
           (use this if all the files have the same encoding)
         "encoding": "ISO-8859-2",
 
-         # pass options to procesors ("http://goodtables.readthedocs.org/en/latest/pipeline.html#validator-options")
+         # pass options to procesors
         "options": {
           "schema": {"case_insensitive_headers": true}
         }
@@ -192,9 +200,11 @@ dq generate generator_name endpoint --config_filepath path/to/config
 }
 ```
 
-### Default config 
+<a name="default-config"/>
+#### Default config
+</a>
 
-````json
+```json
 {
     "data_dir": "current_working_directory/data",
     "cache_dir": "current_working_directory/fetched",
@@ -215,9 +225,70 @@ dq generate generator_name endpoint --config_filepath path/to/config
         }
     }
 }
-````
+```
 
+<a name="quality-config"/>
+#### Quality assessment configuration
+</a>
+
+Currently, Data Quality CLI assesses the quality of a file based on its structure and
+by comparing its contents against a schema. This is done using the
+[built-in processors](http://goodtables.readthedocs.io/en/latest/cli.html) (a.k.a. validators) 
+in [GoodTables](http://goodtables.readthedocs.io/en/latest/).
+
+*Note:*  If the files are compressed, they cannot be found at the specified path or the path returns
+an HTML page, they will be scored 0.
+
+If you want to add other criteria for quality assessment, you can
+[create a custom processor for GoodTables](http://goodtables.readthedocs.io/en/latest/tutorial.html#implementing-a-custom-processor).
+Then include the name of your custom processor in the list passed to the `processors` parameter from [data quality config](###structure-of-json-config):
+`"processors": ["structure", "schema", "custom_processor"]`.
+You can also exclude processors that you don't want by removing them from the list.
+
+##### Structure Processor:
+
+  Checks the structure of a tabular file.
+
+  Ex: blank or duplicate rows, rows that have more/less columns than the header, bad formatting etc.
+
+  Options and their defaults:
+
+  * `ignore_empty_rows: false` - Should empty rows be considered errors or just ignored?
+  * `ignore_duplicate_rows: false` - Should duplicate rows be considered errors or just ignored?
+  * `ignore_empty_columns: false`
+  * `ignore_duplicate_columns: false`
+  * `ignore_headerless_columns: false` - Should values in a row that don't correspond to a column be ignored?
+  * `empty_strings: None` - A list/set of what should be considered empty string, otherwise only `''` will
+
+
+##### Schema Processor:
+
+  Compares the content of a tabular file against a [Json Table Schema](http://specs.frictionlessdata.io/json-table-schema/).
+  You have the following options for the schema:
+
+  1. Provide a path to the schema for each source in `source_file` and [set the "schema_key"](#config) to the name 
+of the column that contains it
+  2. Let GoodTables infer the schema for each file from its first few lines (less transparent).
+
+  Options and defaults: 
+
+  * `ignore_field_order: true` - Should columns have the same order as in the schema?
+  * `infer_schema: false` - Should the schema be infered? (see above)
+  * `process_extra_fields: false` - Should fields that are not present in the schema be infered and checked?
+  * `case_insensitive_headers: false` - Should headers be matched with the equivalent field names from schema regardless of case?
+
+  *Note:* If you use the schema processor but you don't provide a schema to compare against, the files will be evaluated as having no errors.
+
+  To see how using different processors influence the quality assessment, we set up several versions
+  of the same dataset: UK public spend over £25000.
+  
+  This version uses both `structure` and `schema` processors, comparing each file agaist the
+  [spend publishing schema](https://raw.githubusercontent.com/okfn/goodtables/master/examples/hmt/spend-publishing-schema.json).
+
+
+<a name="schema"/>
 ### Schema
+</a>
 
 `Data Quality CLI` expects the following structure of the project folder, where 
 the names of files and folders are the ones defined in the json config given to  `dq run`:
@@ -244,7 +315,7 @@ the `dq generate` command, it will be automatically generated for you.
 An important note is that Data Quality CLI has it's own default datapackage file
 which is used to define the schema for all the files that it creates: `run_file`,
 `result_file`, `performance_file` and, if you use `dq generate`, for `sources_file` and 
-`publisher_file`. Please take a look over [the default datapackage](data_quality/datapackage.json)
+`publisher_file`. Please take a look over [the default datapackage](data_quality/datapackage.default.json)
 to get a better understanding of what these files contain. Also take a look 
 over the [Data Package](http://specs.frictionlessdata.io/data-packages/)
 specification if you'd like to customize the one in your project.


### PR DESCRIPTION
This pull request fixes #17.

I updated the README and added examples with the following versions of uk-25k-spend database:
- `structure` only  (https://uk-25k-structure-only.herokuapp.com/)
- `structure` and `schema`, with [Spend Publishing Schema](https://raw.githubusercontent.com/okfn/goodtables/master/examples/hmt/spend-publishing-schema.json)  (https://uk-25k-given-schema.herokuapp.com/)
- `structure` and `schema`, with inferred schema (https://uk-25k-inferred-schema.herokuapp.com/)
