### PR TITLE
Update datapackage sources after generate

### DIFF
--- a/data_quality/datapackage.default.json
+++ b/data_quality/datapackage.default.json
@@ -47,7 +47,7 @@
                     },
                     {
                         "name": "title",
-                        "title": "Title of the source",
+                        "title": "Title or name of the source",
                         "type": "string",
                         "constraints": { "required": true }
                     },

--- a/data_quality/main.py
+++ b/data_quality/main.py
@@ -95,6 +95,7 @@ def generate(generator_name, endpoint, config_file_path, generator_class_path, f
 
     generator = tasks.GeneratorManager(config)
     generator.run(generator_name, endpoint, generator_class_path, file_types)
+    generator.update_datapackage_sources()
 
 
 @cli.command()

--- a/data_quality/tasks/aggregate.py
+++ b/data_quality/tasks/aggregate.py
@@ -69,8 +69,7 @@ class Aggregator(Task):
 
     def get_lookup(self):
 
-        data_key = self.config['goodtables']['arguments']['batch']['data_key']
-        _keys = ['id', 'publisher_id', data_key, 'period_id']
+        _keys = ['id', 'publisher_id', self.data_key, 'period_id', 'title']
         lookup = []
 
         with compat.UnicodeDictReader(self.source_file) as sources_file:
@@ -94,8 +93,7 @@ class Aggregator(Task):
     def get_source(self, data_src):
         """Find the entry correspoding to data_src from sources file"""
 
-        data_key = self.config['goodtables']['arguments']['batch']['data_key']
-        matches = [match for match in self.lookup if match[data_key] == data_src]
+        matches = [match for match in self.lookup if match[self.data_key] == data_src]
 
         if len(matches) == 0:
             raise exceptions.SourceNotFoundError(source=data_src)
@@ -149,8 +147,7 @@ class Aggregator(Task):
     def fetch_data(self, data_stream, encoding, source):
         """Cache the data source in the /fetched directory"""
 
-        data_key = self.config['goodtables']['arguments']['batch']['data_key']
-        source_name = source.get('name', source[data_key].rsplit('/', 1)[-1])
+        source_name = source.get('name', source[self.data_key].rsplit('/', 1)[-1])
         cached_file_name = os.path.join(self.cache_dir, source_name)
         data_stream.seek(0)
 

--- a/data_quality/tasks/base_task.py
+++ b/data_quality/tasks/base_task.py
@@ -25,7 +25,7 @@ class Task(object):
         self.publisher_file = os.path.join(self.data_dir,
                                            self.config['publisher_file'])
         self.cache_dir = self.config['cache_dir']
-
+        self.data_key = self.config['goodtables']['arguments']['batch']['data_key']
         datapkg_file_path = self.config.get('datapackage_file', 'datapackage.json')
         if not os.path.isabs(datapkg_file_path):
             datapkg_file_path = os.path.join(os.path.dirname(self.data_dir),
@@ -34,5 +34,6 @@ class Task(object):
             self.datapackage = datapackage.DataPackage(datapkg_file_path)
         except datapackage.exceptions.DataPackageException as e:
             raise ValueError(('A datapackage couldn\'t be created because of the '
-                              'following error: "{0}". Consider using "dq init"').format(e))
+                              'following error: "{0}". Make sure the file is not '
+                              'empty and use "dq init" command.').format(e))
         self.all_scores = []

--- a/data_quality/tasks/check_datapackage.py
+++ b/data_quality/tasks/check_datapackage.py
@@ -15,8 +15,11 @@ class DataPackageChecker(Task):
 
     """A task runner to check that the data package is correct"""
 
-    def __init__(self, config):
+    def __init__(self, config, inflexible_resources=[]):
         super(DataPackageChecker, self).__init__(config)
+        self.inflexible_resources = ['run_file', 'result_file', 'performance_file']
+        self.inflexible_resources.extend(inflexible_resources)
+        self.inflexible_resources = set(inflexible_resources)
 
     def run(self):
         """Check user datapackage against default datapackage"""
@@ -32,21 +35,36 @@ class DataPackageChecker(Task):
     def check_resource_schema(self, default_resource, resource):
         """Check that user resource schema contains all the mandatory fields"""
 
-        inflexible_resources = ['run_file', 'result_file', 'performance_file']
-        if default_resource.metadata['name'] in inflexible_resources:
-            if default_resource.metadata['schema'] != resource.metadata['schema']:
-                raise ValueError(('The schema for "{0}" is not subject to'
-                                  'change').format(resource.local_data_path))
+        def get_uncustomizable_fields(schema):
+            uncustomizable = ['constraints', 'format', 'name', 'type']
+            field_filter = lambda field: {key: val for key, val in field.items()
+                                          if key in uncustomizable}
+            fields = [field_filter(field) for field in schema.fields]
+            fields = sorted(fields, key=lambda k: k['name'])
 
         resource_schema = SchemaModel(resource.metadata['schema'])
-        default_schema = SchemaModel(default_resource.metadata['schema'])
-        required_headers = set(default_schema.required_headers)
-        resource_headers = set(resource_schema.headers)
-        if not required_headers.issubset(resource_headers):
-            missing_headers = required_headers.difference(resource_headers)
-            msg = ('Fields {0} are needed for internal processing but are missing'
-                   'from {1}.').format(missing_headers, resource.local_data_path)
-            raise ValueError(msg)
+        default_schema_dict = default_resource.metadata['schema']
+        if default_resource.metadata['name'] == 'source_file':
+            for field in default_schema_dict['fields']:
+                if field['name'] == 'data':
+                    field['name'] = self.data_key
+        default_schema = SchemaModel(default_schema_dict)
+
+        if default_resource.metadata['name'] in self.inflexible_resources:
+            if get_uncustomizable_fields(default_schema) != \
+               get_uncustomizable_fields(resource_schema):
+                msg = ('The fields for "{0}" are not subject to'
+                       'change').format(resource.local_data_path)
+                raise ValueError(msg, resource.local_data_path)
+        else:
+            required_headers = set(default_schema.required_headers)
+            resource_headers = set(resource_schema.headers)
+            if not required_headers.issubset(resource_headers):
+                missing_headers = required_headers.difference(resource_headers)
+                msg = ('Fields {0} are needed for internal processing'
+                       'but are missing from {1}.'
+                       ).format(missing_headers, resource.local_data_path)
+                raise ValueError(msg, resource.local_data_path)
 
     def check_database_content(self):
         """Check that the database content is compliant with the datapackage"""
@@ -63,11 +81,12 @@ class DataPackageChecker(Task):
                     issues = [res['result_message'] for res in report.generate()['results']]
                     msg = ('The file {0} is not compliant with the schema '
                            'you declared for it in "datapackage.json".'
-                           'Errors: {1}').format(resource_path, ','.join(issues))
+                           'Errors: {1}'
+                          ).format(resource_path, ','.join(issues))
                     raise ValueError(msg)
 
     def check_database_completeness(self, required_resources=None):
-        """Checks that 'required_resources', or all necessary ones exists in the database
+        """Checks that 'required_resources', or all necessary ones exist in the database
 
             Args:
                 required_resources: list of paths to required resources
@@ -77,5 +96,7 @@ class DataPackageChecker(Task):
         resources = required_resources or all_resources
         for resource_file in resources:
             if not os.path.exists(resource_file):
-                raise ValueError(('The file "{0}" is needed but it doesn\'t exist.'
-                                  'Please create it or use "dq generate".').format(resource_file))
+                msg = ('The file "{0}" is needed but it doesn\'t exist.'
+                       'Please create it or use "dq generate".'
+                      ).format(resource_file)
+                raise ValueError(msg)

--- a/data_quality/tasks/deploy.py
+++ b/data_quality/tasks/deploy.py
@@ -92,10 +92,12 @@ class Deployer(Task):
     def update_last_modified(self):
         """Update the 'last_modified' field in datapackage.json"""
 
-        datapackage_path = os.path.join(self.datapackage.base_path, 'datapackage.json')
+        datapackage_path = os.path.join(self.datapackage.base_path,
+                                        'datapackage.json')
 
         with io.open(datapackage_path, mode='w+', encoding='utf-8') as datapkg_file:
             current_time = strftime("%Y-%m-%d %H:%M:%S %Z", gmtime())
             self.datapackage.metadata['last_modified'] = current_time
-            updated_json = json.dumps(self.datapackage, indent=4)
-            datapkg_file.write(compat.str(updated_json))
+            updated_datapkg = json.dumps(self.datapackage.to_dict(), indent=4,
+                                         sort_keys=True)
+            datapkg_file.write(compat.str(updated_datapkg))

--- a/data_quality/tasks/generate.py
+++ b/data_quality/tasks/generate.py
@@ -4,8 +4,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
+import io
+import json
 import importlib
-from data_quality import generators, utilities
+from data_quality import generators, utilities, compat
 from .base_task import Task
 from .check_datapackage import DataPackageChecker
 
@@ -29,19 +32,17 @@ class GeneratorManager(Task):
             file_types: List of file types that should be included in sources
         """
 
-        if  generators._built_in_generators.get(generator_name, None):
-            default_datapkg = utilities.get_default_datapackage()
-            default_resources = [res for res in default_datapkg.resources
-                                 if res.metadata['name'] in ['source_file', 'publisher_file']]
-            user_resources = [utilities.get_datapackage_resource(path, self.datapackage)
-                              for path in [self.publisher_file, self.source_file]]
-            for default_resource, resource in zip(default_resources, user_resources):
-                if default_resource.metadata['schema'] != resource.metadata['schema']:
-                    msg = ('Looks like you have a custom schema for "{0}". Generator '
-                           '"{1}" only works with the default schema. Please use '
-                           'a custom generator or match your schema to the default one.'
-                          ).format(default_resource.metadata['name'], generator_name)
-                    raise ValueError(msg)
+        if generators._built_in_generators.get(generator_name, None):
+            inflexible_resources = ['source_file', 'publisher_file']
+            datapackage_check = DataPackageChecker(self.config, inflexible_resources)
+            try:
+                datapackage_check.run()
+            except ValueError as e:
+                msg = ('Looks like you have a custom schema for "{0}". Generator '
+                       '"{1}" only works with the default schema. Please use a '
+                       'custom generator or match your schema to the default one.'
+                      ).format(e[1], generator_name)
+                raise ValueError(msg)
 
             generator_class = generators._built_in_generators[generator_name]
         else:
@@ -59,3 +60,22 @@ class GeneratorManager(Task):
         generator.generate_publishers(self.publisher_file)
         generator.generate_sources(self.source_file, file_types=file_types)
 
+    def update_datapackage_sources(self):
+        """Update the 'sources' property of datapackage with the new sources"""
+
+        datapackage_check = DataPackageChecker(self.config)
+        required_resources = [self.source_file, self.publisher_file]
+        datapackage_check.check_database_completeness(required_resources)
+        datapackage_check.run()
+        self.datapackage.metadata['sources'] = []
+        datapkg_path = os.path.join(self.datapackage.base_path, 'datapackage.json')
+
+        with compat.UnicodeDictReader(self.source_file) as sources_file:
+            for source in sources_file:
+                src_info = {'name': source['title'], 'web': source[self.data_key]}
+                self.datapackage.metadata['sources'].append(src_info)
+
+        with io.open(datapkg_path, mode='w+', encoding='utf-8') as datapkg_file:
+            new_datapkg = json.dumps(self.datapackage.to_dict(), indent=4,
+                                     sort_keys=True)
+            datapkg_file.write(compat.str(new_datapkg))

--- a/tests/fixtures/datapackage.json
+++ b/tests/fixtures/datapackage.json
@@ -1,61 +1,75 @@
 {
-    "name": "",
-    "last_modified": "",
-    "validator_url": "https://goodtables.okfnlabs.org/api/run",
     "admin": "",
-    "pitch": "",
     "context": "",
-    "sources": [{"name": "", "web": ""}],
+    "last_modified": "",
+    "name": "",
+    "pitch": "",
     "resources": [
         {
-           "path": "publishers.csv",
-           "name": "publisher_file",
-           "schema": {
+            "name": "publisher_file",
+            "path": "publishers.csv",
+            "schema": {
                 "fields": [
-                  {
-                    "name": "id",
-                    "title": "ID of the publisher",
-                    "type": "string",
-                    "constraints": { "required": true, "unique": true }
-                  },
-                  {
-                    "name": "title",
-                    "title": "Title or official name of the publisher",
-                    "type": "string",
-                    "constraints": { "required": true, "unique": true }
-                  }
+                    {
+                        "constraints": {
+                            "required": true,
+                            "unique": true
+                        },
+                        "name": "id",
+                        "title": "ID of the publisher",
+                        "type": "string"
+                    },
+                    {
+                        "constraints": {
+                            "required": true,
+                            "unique": true
+                        },
+                        "name": "title",
+                        "title": "Title or official name of the publisher",
+                        "type": "string"
+                    }
                 ],
                 "primaryKey": "id"
             }
         },
         {
-            "path": "sources.csv",
             "name": "source_file",
+            "path": "sources.csv",
             "schema": {
                 "fields": [
                     {
+                        "constraints": {
+                            "required": true,
+                            "unique": true
+                        },
                         "name": "id",
                         "title": "ID of the source",
-                        "type": "string",
-                        "constraints": { "required": true, "unique": true }
+                        "type": "string"
                     },
                     {
+                        "constraints": {
+                            "required": true,
+                            "unique": true
+                        },
                         "name": "publisher_id",
                         "title": "ID of the source's publisher",
-                        "type": "string",
-                        "constraints": { "required": true, "unique": true }
+                        "type": "string"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "title",
                         "title": "Title of the source",
-                        "type": "string",
-                        "constraints": { "required": true }
+                        "type": "string"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "data",
                         "title": "Path/url to source",
-                        "type": "string",
-                        "constraints": { "required": true }
+                        "type": "string"
                     },
                     {
                         "name": "format",
@@ -63,86 +77,107 @@
                         "type": "string"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "period_id",
                         "title": "Time covered by the source / of its creation",
-                        "type": "string",
-                        "constraints": { "required": true }
+                        "type": "string"
                     }
                 ],
-                "primaryKey": "id",
                 "foreignKeys": [
                     {
                         "fields": "publisher_id",
                         "reference": {
-                            "resource": "publisher_file",
-                            "fields": "id"
+                            "fields": "id",
+                            "resource": "publisher_file"
                         }
-                    }
-                ]
-            }
-        },
-        {
-            "path": "runs.csv",
-            "name": "run_file",
-            "schema": {
-                "fields": [
-                    {
-                        "name": "id",
-                        "title": "ID of the run",
-                        "type": "string",
-                        "constraints": { "required": true, "unique": true }
-                    },
-                    {
-                        "name": "timestamp",
-                        "title": "Timestamp of the run execution",
-                        "type": "date",
-                        "format": "datetime",
-                        "constraints": { "required": true }
-                    },
-                    {
-                        "name": "total_score",
-                        "title": "Rounded average score of results in this run",
-                        "type": "integer",
-                        "constraints": { "required": true}
                     }
                 ],
                 "primaryKey": "id"
             }
         },
         {
-            "path": "results.csv",
-            "name": "result_file",
+            "name": "run_file",
+            "path": "runs.csv",
             "schema": {
                 "fields": [
-                   {
+                    {
+                        "constraints": {
+                            "required": true,
+                            "unique": true
+                        },
+                        "name": "id",
+                        "title": "ID of the run",
+                        "type": "string"
+                    },
+                    {
+                        "constraints": {
+                            "required": true
+                        },
+                        "format": "datetime",
+                        "name": "timestamp",
+                        "title": "Timestamp of the run execution",
+                        "type": "date"
+                    },
+                    {
+                        "constraints": {
+                            "required": true
+                        },
+                        "name": "total_score",
+                        "title": "Rounded average score of results in this run",
+                        "type": "integer"
+                    }
+                ],
+                "primaryKey": "id"
+            }
+        },
+        {
+            "name": "result_file",
+            "path": "results.csv",
+            "schema": {
+                "fields": [
+                    {
+                        "constraints": {
+                            "required": true,
+                            "unique": true
+                        },
                         "name": "id",
                         "title": "ID of the result",
-                        "type": "string",
-                        "constraints": { "required": true, "unique": true }
+                        "type": "string"
                     },
                     {
+                        "constraints": {
+                            "required": true,
+                            "unique": true
+                        },
                         "name": "source_id",
                         "title": "ID of the correspoding source",
-                        "type": "string",
-                        "constraints": { "required": true, "unique": true }
+                        "type": "string"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "publisher_id",
                         "title": "ID of the source's publisher",
-                        "type": "string",
-                        "constraints": { "required": true}
+                        "type": "string"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "period_id",
                         "title": "Time covered by the source / of its creation",
-                        "type": "string",
-                        "constraints": { "required": true }
+                        "type": "string"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "data",
                         "title": "Path/url to source",
-                        "type": "string",
-                        "constraints": { "required": true }
+                        "type": "string"
                     },
                     {
                         "name": "schema",
@@ -150,10 +185,12 @@
                         "type": "string"
                     },
                     {
+                        "contrains": {
+                            "required": true
+                        },
                         "name": "score",
                         "title": "Score of correctness given by GoodTables",
-                        "type": "integer",
-                        "contrains": { "required": true }
+                        "type": "integer"
                     },
                     {
                         "name": "summary",
@@ -161,17 +198,22 @@
                         "type": "string"
                     },
                     {
+                        "constraints": {
+                            "required": true,
+                            "unique": true
+                        },
                         "name": "run_id",
                         "title": "ID of the run in which the result was calculated",
-                        "type": "string",
-                        "constraints": { "required": true, "unique": true }
+                        "type": "string"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
+                        "format": "datetime",
                         "name": "timestamp",
                         "title": "Timestamp of the run execution",
-                        "type": "date",
-                        "format": "datetime",
-                        "constraints": { "required": true }
+                        "type": "date"
                     },
                     {
                         "name": "report",
@@ -179,96 +221,115 @@
                         "type": "string"
                     }
                 ],
-                "primaryKey": "id",
                 "foreignKeys": [
                     {
-                       "fields": "source_id",
-                       "reference": {
-                            "resource": "source_file",
-                            "fields": "id"
-                       }
+                        "fields": "source_id",
+                        "reference": {
+                            "fields": "id",
+                            "resource": "source_file"
+                        }
                     },
                     {
-                       "fields": "publisher_id",
-                       "reference": {
-                            "resource": "publisher_file",
-                            "fields": "id"
-                       }
+                        "fields": "publisher_id",
+                        "reference": {
+                            "fields": "id",
+                            "resource": "publisher_file"
+                        }
                     },
                     {
-                       "fields": "run_id",
-                       "reference": {
-                            "resource": "run_file",
-                            "fields": "id"
-                       }
+                        "fields": "run_id",
+                        "reference": {
+                            "fields": "id",
+                            "resource": "run_file"
+                        }
                     }
-                ]
+                ],
+                "primaryKey": "id"
             }
         },
         {
-            "path": "performance.csv",
             "name": "performance_file",
+            "path": "performance.csv",
             "schema": {
                 "fields": [
                     {
+                        "constraints": {
+                            "required": true,
+                            "unique": true
+                        },
                         "name": "publisher_id",
                         "title": "ID of the publisher",
-                        "type": "string",
-                        "constraints": { "required": true, "unique": true }
+                        "type": "string"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "period_id",
                         "title": "ID of the period",
-                        "type": "string",
-                        "constraints": { "required": true }
+                        "type": "string"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "files_count",
                         "title": "Number of files published by the publisher during period",
-                        "type": "integer",
-                        "constraints": { "required": true }
+                        "type": "integer"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "score",
                         "title": "Rounded average score of files published by the publisher during period",
-                        "type": "integer",
-                        "constraints": { "required": true }
+                        "type": "integer"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "valid",
                         "title": "Number of valid files published by the publisher during period",
-                        "type": "integer",
-                        "constraints": { "required": true }
+                        "type": "integer"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "files_count_to_date",
                         "title": "Number of files published by the publisher up to period",
-                        "type": "integer",
-                        "constraints": { "required": true }
+                        "type": "integer"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "score_to_date",
                         "title": "Rounded average score of files published by the publisher up to period",
-                        "type": "integer",
-                        "constraints": { "required": true }
+                        "type": "integer"
                     },
                     {
+                        "constraints": {
+                            "required": true
+                        },
                         "name": "valid_to_date",
                         "title": "Number of valid files published by the publisher up to period",
-                        "type": "integer",
-                        "constraints": { "required": true }
+                        "type": "integer"
                     }
                 ],
                 "foreignKeys": [
                     {
                         "fields": "publisher_id",
                         "reference": {
-                            "resource": "publisher_file",
-                            "fields": "id"
+                            "fields": "id",
+                            "resource": "publisher_file"
                         }
                     }
                 ]
             }
         }
-    ]
+    ],
+    "sources": [],
+    "validator_url": "https://goodtables.okfnlabs.org/api/run"
 }

--- a/tests/fixtures/sources.csv
+++ b/tests/fixtures/sources.csv
@@ -1,3 +1,3 @@
-id,publisher_id,name,data,score,revision,schema,period_id,timestamp,format
+id,publisher_id,title,data,score,revision,schema,period_id,timestamp,format
 source1,xx_dept1,Source 1,https://raw.githubusercontent.com/okfn/tabular-validator/master/examples/valid.csv,8,1,,2015-01-01,2015-01-01,csv
 source2,xx_dept15,Source 15,https://raw.githubusercontent.com/okfn/goodtables/master/examples/april-to-may-12th-2010.xls,8,1,,2015-01-01,2015-01-01,excel

--- a/tests/tasks/test_generate.py
+++ b/tests/tasks/test_generate.py
@@ -6,6 +6,8 @@ from __future__ import unicode_literals
 
 import unittest
 import os
+import io
+import json
 from data_quality import tasks, utilities, compat, generators
 from tests import mock_generator
 from .test_task import TestTask
@@ -32,3 +34,23 @@ class TestGeneratorManagerTask(TestTask):
 
         self.assertIsInstance(generator_class, mock_generator.MockGenerator)
 
+    def test_generate_update_datapackage_sources(self):
+        """Test that GeneratorManager task updates datapackage sources"""
+
+        def empty_datapackage_sources(datapkg_path, datapkg):
+            with io.open(datapkg_path, mode='w+', encoding='utf-8') as datapkg_file:
+                datapkg.metadata['sources'] = []
+                updated_json = json.dumps(datapkg.to_dict(), indent=4, sort_keys=True)
+                datapkg_file.write(compat.str(updated_json))
+
+        generator = tasks.GeneratorManager(self.config)
+        datapkg_path = os.path.join(generator.datapackage.base_path,
+                                    'datapackage.json')
+        empty_datapackage_sources(datapkg_path, generator.datapackage)
+        generator.update_datapackage_sources()
+        second_generator = tasks.GeneratorManager(self.config)
+
+        self.assertEquals(generator.datapackage.metadata['sources'],
+                          second_generator.datapackage.metadata['sources'])
+        self.assertGreater(len(generator.datapackage.metadata['sources']), 0)
+        empty_datapackage_sources(datapkg_path, generator.datapackage)


### PR DESCRIPTION
This pull request fixes #22  .

It has been added after generation not after fetching as initially thought because fetching treats sources individually. 
I also changed the `CheckDataPackage` task to take into consideration the optional use of a different  `data_key`. 
