### PR TITLE
Relative paths for config and datapackage

### DIFF
--- a/data_quality/main.py
+++ b/data_quality/main.py
@@ -85,7 +85,9 @@ def generate(generator_name, endpoint, config_file_path, generator_class_path, f
     file_types = list(file_type)
     config = utilities.load_json_config(config_file_path)
     if not config_file_path:
-        config['data_dir'] = utilities.resolve_dir_name(os.getcwd(), config['data_dir'])
+        default_config_path = os.path.join(os.getcwd(), 'dq_config.json')
+        config['data_dir'] = utilities.resolve_dir_name(default_config_path,
+                                                        config['data_dir'])
     utilities.resolve_dir(config['data_dir'])
 
     if generator_name not in generators._built_in_generators.keys():

--- a/data_quality/tasks/initialize_datapackage.py
+++ b/data_quality/tasks/initialize_datapackage.py
@@ -38,10 +38,6 @@ class DataPackageInitializer(object):
             config = utilities.load_json_config(init_config_path)
         else:
             config = utilities.load_json_config(None)
-            config['data_dir'] = utilities.resolve_dir_name(init_config_path,
-                                                            config['data_dir'])
-            config['cache_dir'] = utilities.resolve_dir_name(init_config_path,
-                                                             config['cache_dir'])
 
             with io.open(init_config_path, mode='w+', encoding='utf-8') as new_config:
                 new_json_config = json.dumps(config, indent=4, sort_keys=True)
@@ -55,9 +51,7 @@ class DataPackageInitializer(object):
 
         datapkg_file_path = config.get('datapackage_file', '')
         if not datapkg_file_path or not os.path.isabs(datapkg_file_path):
-            data_dir_path = os.path.normpath(config['data_dir'])
-            datapkg_dir_path = os.path.dirname(data_dir_path)
-            datapkg_file_path = os.path.join(datapkg_dir_path, 'datapackage.json')
+            datapkg_file_path = os.path.join(self.workspace_path, 'datapackage.json')
 
         datapkg_file_path = os.path.abspath(datapkg_file_path)
         if not os.path.exists(datapkg_file_path):
@@ -67,7 +61,7 @@ class DataPackageInitializer(object):
                     resource_path = config.get(resource.descriptor['name'],
                                                resource.descriptor['path'])
                     resource.descriptor['path'] = os.path.join(config['data_dir'],
-                                                             resource_path)
+                                                               resource_path)
                 json_datapkg = json.dumps(default_datapkg.to_dict(), indent=4)
                 new_datapkg.write(compat.str(json_datapkg))
                 print(('A new "datapackage.json" file has been created at {0}. '


### PR DESCRIPTION
All paths in documents generated with `init` command were absolute which made collaborations on the same repo cumbersome. This fixes that issue.
